### PR TITLE
Add unzip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,3 +124,17 @@ RUN apt-get update -y && \
   apt-get install -y --no-install-recommends libxml2=${LIBXML_VERSION} && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+
+# Install tools required by Sonar extension for Azure DevOps
+
+# renovate: datasource=repology depName=debian_12/unzip versioning=deb
+ENV UNZIP_VERSION=6.0
+
+RUN apt-get update -y && \
+  # Install unzip
+  apt-get install -y --no-install-recommends unzip=${UNZIP_VERSION}-28 && \
+  # Clean up
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  # Smoke test
+  unzip --hh


### PR DESCRIPTION
Add unzip to the image which is required when using Sonar extension for Azure DevOps 2.0 which downloads the scanner instead of having them embedded in the extension.