### PR TITLE
Split long RUN instructions into multiple lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,14 @@ RUN apt-get update -y && \
   # Install necessary dependencies
   apt-get install -y --no-install-recommends curl=${CURL_VERSION} && \
   # Add Git LFS PPA
-  curl --proto "=https" -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
+  curl --proto "=https" -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh \
+    | bash && \
   # Add NodeJS PPA
-  curl --proto "=https" -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  curl --proto "=https" -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
   NODE_MAJOR=20 && \
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+    | tee /etc/apt/sources.list.d/nodesource.list && \
   # Add .NET PPA
   curl --proto "=https" -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb && \
   dpkg -i /tmp/packages-microsoft-prod.deb && \


### PR DESCRIPTION
Split long RUN instructions into multiple lines to make it easier to read and understand.

Fixes https://rules.sonarsource.com/docker/RSPEC-7020/